### PR TITLE
suggest pip install

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ The usual should work:
 
 .. code-block:: shell
 
-   $ sudo python setup.py install
+   $ sudo pip install .
 
 Getting started
 ---------------


### PR DESCRIPTION
when using setuptools,
the install command is an alias for `easy_install .` die to pretty horrific legacy reasons

this brings in setuptools dependency management and encapsulated egg installs
(which is in general a bad idea to throw into a global python, since afterwards ALL system python tools pay the egg cost due to the easyinstall pth)