### PR TITLE
Also look for `nanomsg/*.h` in `CPATH` if present.

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -2,6 +2,8 @@ from cffi import FFI
 import os
 
 INCLUDE = ['/usr/include/nanomsg', '/usr/local/include/nanomsg']
+if 'CPATH' in os.environ:
+    INCLUDE += [os.path.join(p, 'nanomsg') for p in os.getenv('CPATH').split(os.pathsep)]
 BLOCKS = {'{': '}', '(': ')'}
 
 def header_files():


### PR DESCRIPTION
This is useful for local installs of nanomsg, as gcc also looks there by default (See https://gcc.gnu.org/onlinedocs/gcc/Environment-Variables.html)