### PR TITLE
support cross compiling

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -15,13 +15,13 @@ def header_files():
     return {fn: os.path.join(dir, fn) for fn in os.listdir(dir)}
 
 def functions(hfiles):
-    
+
     lines = []
     for fn, path in hfiles.items():
         with open(path) as f:
             cont = ''
             for ln in f:
-                
+
                 if cont == ',':
                     lines.append(ln)
                     cont = ''
@@ -32,27 +32,27 @@ def functions(hfiles):
                 if not (ln.startswith('NN_EXPORT')
                     or ln.startswith('typedef')):
                     continue
-                
+
                 lines.append(ln)
                 cont = ln.strip()[-1]
-    
+
     return ''.join(ln[10:] if ln.startswith('NN_') else ln for ln in lines)
 
 def symbols(ffi):
-    
+
     nanomsg = ffi.dlopen('nanomsg')
     lines = []
     for i in range(1024):
-        
+
         val = ffi.new('int*')
         name = nanomsg.nn_symbol(i, val)
         if name == ffi.NULL:
             break
-        
+
         name = ffi.string(name).decode()
         name = name[3:] if name.startswith('NN_') else name
         lines.append('%s = %s' % (name, val[0]))
-    
+
     return '\n'.join(lines) + '\n'
 
 def create_module():


### PR DESCRIPTION
This patch adds support for cross compiling nnpy (e.g. under [Buildroot](https://buildroot.org/)). I modeled  the changes after what numpy seemingly does (using a site.cfg file if one is present).