### PR TITLE
Improve raised exceptions

### DIFF
--- a/nnpy/errors.py
+++ b/nnpy/errors.py
@@ -1,8 +1,8 @@
 from _nnpy import ffi, lib as nanomsg
 
 class NNError(Exception):
-    def __init__(self, result_code, error_no, *args, **kwargs):
-        self.result_code = result_code
+    def __init__(self, error_no, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.error_no = error_no
 
 def convert(rc, value=None):

--- a/nnpy/errors.py
+++ b/nnpy/errors.py
@@ -6,7 +6,7 @@ class NNError(Exception):
 def convert(rc, value=None):
     if rc < 0:
         chars = nanomsg.nn_strerror(nanomsg.nn_errno())
-        raise NNError(ffi.string(chars))
+        raise NNError(ffi.string(chars).decode())
     if callable(value):
         return value()
     return value

--- a/nnpy/errors.py
+++ b/nnpy/errors.py
@@ -1,12 +1,16 @@
 from _nnpy import ffi, lib as nanomsg
 
 class NNError(Exception):
-    pass
+    def __init__(self, result_code, error_no, *args, **kwargs):
+        self.result_code = result_code
+        self.error_no = error_no
 
 def convert(rc, value=None):
     if rc < 0:
-        chars = nanomsg.nn_strerror(nanomsg.nn_errno())
-        raise NNError(ffi.string(chars).decode())
+        error_no = nanomsg.nn_errno()
+        chars = nanomsg.nn_strerror(error_no)
+        msg = ffi.string(chars).decode()
+        raise NNError(rc, error_no, msg)
     if callable(value):
         return value()
     return value


### PR DESCRIPTION
Improve raised exceptions
- convert message from bytes to string when using Python 3  (using `str.decode` should work on both Python 2.x and Python 3)
- add result code and errno values to the `NNError` exception class when raising an exception

The last change allows to react appropriately when we are interested in specific `errno`, i.e. `EAGAIN` to repeat send operation.