### PR TITLE
Return poll result for all SP sockets, not first socket only.

### DIFF
--- a/nnpy/__init__.py
+++ b/nnpy/__init__.py
@@ -14,4 +14,4 @@ class PollSet(object):
 
     def poll(self, timeout=0):
         rc = nanomsg.nn_poll(self.fd_set, len(self.data), timeout)
-        return errors.convert(rc, lambda: self.fd_set[0].revents)
+        return errors.convert(rc, lambda: [fd.revents for fd in self.fd_set])


### PR DESCRIPTION
As in the title, we need to return all poll results from `PollSet.poll` method.
