### PR TITLE
Fix incorrect args to super

### DIFF
--- a/nnpy/errors.py
+++ b/nnpy/errors.py
@@ -2,7 +2,7 @@ from _nnpy import ffi, lib as nanomsg
 
 class NNError(Exception):
     def __init__(self, error_no, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super(NNError, self).__init__(*args, **kwargs)
         self.error_no = error_no
 
 def convert(rc, value=None):


### PR DESCRIPTION
The arguments to the call to `super` within `NNError` are incorrect, resulting in:

```
File "/home/mpelland/.python_envs/chatty/lib/python2.7/site-packages/nnpy/socket.py", line 85, in recv
    errors.convert(rc)
  File "/home/mpelland/.python_envs/chatty/lib/python2.7/site-packages/nnpy/errors.py", line 13, in convert
    raise NNError(error_no, msg)
  File "/home/mpelland/.python_envs/chatty/lib/python2.7/site-packages/nnpy/errors.py", line 5, in __init__
    super().__init__(*args, **kwargs)
TypeError: super() takes at least 1 argument (0 given)
```

Reproduction scenario:

1. Open a REQ-REP pair
2. Set `SNDTIMEO` using `setsockopt`
3. Attempt to receive